### PR TITLE
Add "graphviz" keyword to desktop file

### DIFF
--- a/data/com.github.artemanufrij.graphui.desktop.in
+++ b/data/com.github.artemanufrij.graphui.desktop.in
@@ -2,7 +2,7 @@
 Name=GraphUI
 GenericName=GraphUI
 Comment=Graph Visualization
-Keywords=graph;visual;draw;
+Keywords=graph;visual;draw;graphviz;
 Exec=com.github.artemanufrij.graphui %U
 Icon=com.github.artemanufrij.graphui
 Terminal=false


### PR DESCRIPTION
I had this app installed but could not remember its name. The word "graphviz" appears in the appdata but GNOME Shell only uses the desktop file to find search results for installed apps.